### PR TITLE
Make forward speed configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ r sensor.
 - Publishes velocity commands as `geometry_msgs/msg/Twist` messages on `/cmd_vel`.
 - Uses PD control on luminance error to steer the robot along a line.
 - Configurable parameters for luminance threshold, proportional gain (kp), and derivative gain (kd).
-- Constant forward linear velocity.
+- Constant forward linear velocity set via a parameter.
 
 ## Parameters
 - `threshold` (float): Luminance threshold for the controller, default 0.46.
 - `kp` (float): Proportional gain, default -0.64.
 - `kd` (float): Derivative gain, default -1.2.
+- `speed` (float): Forward linear velocity, default 0.05.
 
 ## Usage
 Run the node using ROS2 launch or directly with:

--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -8,6 +8,7 @@
   - The steering angle is determined by a PD controller using **sensor value − threshold** as the error.
     The derivative term is computed from the change in error between control intervals.
   - Threshold and gain parameters are configurable via ROS 2 parameters.
+  - Constant forward velocity is configurable via a parameter.
   - The vehicle remains stationary until the first `/color` message is received.
   - The `/color` subscription uses the `sensor_data` QoS profile so that it works
     with publishers using best effort reliability.

--- a/etrobo_runner/etrobo_runner.py
+++ b/etrobo_runner/etrobo_runner.py
@@ -18,6 +18,8 @@ class Runner(Node):
         Proportional gain.
     kd : float
         Derivative gain.
+    speed : float
+        Forward linear velocity.
     """
 
     def __init__(self) -> None:
@@ -38,6 +40,7 @@ class Runner(Node):
         self.threshold = self.declare_parameter('threshold', 0.46).value
         self.kp = self.declare_parameter('kp', -0.64).value
         self.kd = self.declare_parameter('kd', -1.2).value
+        self.speed = self.declare_parameter('speed', 0.05).value
 
         self.timer_period = 0.01
         self.create_timer(self.timer_period, self.publish_cmd_vel)
@@ -64,7 +67,7 @@ class Runner(Node):
         print(f' {self.luminance:.3f}, {error:.3f}, {derivative:.3f}, '
               f'{angular:.3f}')
 
-        twist.linear.x = 0.05
+        twist.linear.x = self.speed
         twist.angular.z = angular
         self.publisher_.publish(twist)
 


### PR DESCRIPTION
## Summary
- add a `speed` parameter in runner code
- document the new parameter in README and DESIGN

## Testing
- `colcon test --packages-select etrobo_simulator` *(fails: colcon not found)*

------
https://chatgpt.com/codex/tasks/task_e_68611865e228832f85e9c11d6b03e3cd